### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/im2txt/evaluate.py
+++ b/im2txt/evaluate.py
@@ -143,7 +143,7 @@ def run_once(model, saver, summary_writer, summary_op):
           global_step=global_step,
           summary_writer=summary_writer,
           summary_op=summary_op)
-    except Exception, e:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
       tf.logging.error("Evaluation failed.")
       coord.request_stop(e)
 


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.