### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/im2txt/evaluate.py
+++ b/im2txt/evaluate.py
@@ -34,6 +34,11 @@ import tensorflow as tf
 from im2txt import configuration
 from im2txt import show_and_tell_model
 
+try:
+  xrange
+except NameError:  # Python 3
+  xrange = range
+
 FLAGS = tf.flags.FLAGS
 
 tf.flags.DEFINE_string("input_file_pattern", "",


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__ so this PR ensures equivalent functionality on both Python 2 and Python 3.